### PR TITLE
Feat/#20

### DIFF
--- a/KioskApp/KioskApp/Beverages.json
+++ b/KioskApp/KioskApp/Beverages.json
@@ -4,1022 +4,876 @@
             "name": "사라다빵",
             "price": 3000,
             "category": "Dessert",
-            "option": null,
             "brand": "Paik"
         },
         {
             "name": "소세지빵",
             "price": 3500,
             "category": "Dessert",
-            "option": null,
             "brand": "Paik"
         },
         {
             "name": "소프트아이스크림",
             "price": 2000,
             "category": "Dessert",
-            "option": null,
             "brand": "Paik"
         },
         {
             "name": "쫀득감자빵",
             "price": 2800,
             "category": "Dessert",
-            "option": null,
             "brand": "Paik"
         },
         {
             "name": "쫀득고구마빵",
             "price": 2800,
             "category": "Dessert",
-            "option": null,
             "brand": "Paik"
         },
         {
             "name": "크리미단팥빵",
             "price": 2000,
             "category": "Dessert",
-            "option": null,
             "brand": "Paik"
         },
         {
             "name": "크리미슈",
             "price": 2000,
             "category": "Dessert",
-            "option": null,
             "brand": "Paik"
         },
         {
             "name": "햄치즈샌드위치",
             "price": 3300,
             "category": "Dessert",
-            "option": null,
             "brand": "Paik"
         },
         {
             "name": "고메버터소금빵",
             "price": 2500,
             "category": "Dessert",
-            "option": null,
             "brand": "Paik"
         },
         {
             "name": "딸기라떼",
             "price": 3800,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Paik"
         },
         {
             "name": "미숫가루",
             "price": 2700,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Paik"
         },
         {
             "name": "뱅쇼",
             "price": 3800,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Paik"
         },
         {
             "name": "아망추(아이스티+망고추가)",
             "price": 3800,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Paik"
         },
         {
             "name": "초코라떼",
             "price": 3500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Paik"
         },
         {
             "name": "원조빽스치노(SOFT)",
             "price": 3800,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Paik"
         },
         {
             "name": "청포도에이드",
             "price": 4000,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Paik"
         },
         {
             "name": "쿠키크런치빽스치노(BASIC)",
             "price": 3800,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Paik"
         },
         {
             "name": "퐁당치노(바닐라)",
             "price": 3800,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Paik"
         },
         {
             "name": "플레인요거트스무디",
             "price": 3500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Paik"
         },
         {
             "name": "황금캐모마일티",
             "price": 2500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Paik"
         },
         {
             "name": "토피넛라떼",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Paik"
         },
         {
             "name": "자몽티",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Paik"
         },
         {
             "name": "유자티",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Paik"
         },
         {
             "name": "쌍화차",
             "price": 3000,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Paik"
         },
         {
             "name": "뱅쇼",
             "price": 3800,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Paik"
         },
         {
             "name": "바나나라떼",
             "price": 4000,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Paik"
         },
         {
             "name": "민트초코라떼",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Paik"
         },
         {
             "name": "레몬티",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Paik"
         },
         {
             "name": "깔라만시티",
             "price": 3000,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Paik"
         },
         {
             "name": "달달연유라떼",
             "price": 3700,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Paik"
         },
         {
             "name": "더블에스프레소",
             "price": 1500,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Paik"
         },
         {
             "name": "바나나카페라떼",
             "price": 4000,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Paik"
         },
         {
             "name": "바닐라라떼",
             "price": 3700,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Paik"
         },
         {
             "name": "빽s라떼",
             "price": 3000,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Paik"
         },
         {
             "name": "앗메리카노",
             "price": 2000,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Paik"
         },
         {
             "name": "원조커피",
             "price": 2500,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Paik"
         },
         {
             "name": "카라멜마키아또",
             "price": 3500,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Paik"
         },
         {
             "name": "카페모카",
             "price": 3500,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Paik"
         },
         {
             "name": "바닐라라떼",
             "price": 3700,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Paik"
         },
         {
             "name": "블랙펄카페라떼",
             "price": 4500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Paik"
         },
         {
             "name": "빽s라떼",
             "price": 3000,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Paik"
         },
         {
             "name": "아샷추(달콤아이스티+샷추가)",
             "price": 3000,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Paik"
         },
         {
             "name": "아이스크림바닐라라떼",
             "price": 4400,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Paik"
         },
         {
             "name": "아이스크림카페라떼",
             "price": 3700,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Paik"
         },
         {
             "name": "앗메리카노",
             "price": 1500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Paik"
         },
         {
             "name": "원조커피",
             "price": 2500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Paik"
         },
         {
             "name": "카라멜마키아또",
             "price": 3500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Paik"
         },
         {
             "name": "카페모카",
             "price": 3500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Paik"
         },
         {
             "name": "군고구마라떼",
             "price": 3500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "TheVenti"
         },
         {
             "name": "로얄밀크티",
             "price": 3500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "TheVenti"
         },
         {
             "name": "리치캐모마일",
             "price": 2500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "TheVenti"
         },
         {
             "name": "말차라떼",
             "price": 3500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "TheVenti"
         },
         {
             "name": "멜팅초코",
             "price": 3900,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "TheVenti"
         },
         {
             "name": "미숫가루라떼",
             "price": 3500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "TheVenti"
         },
         {
             "name": "애플히비스커스",
             "price": 2500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "TheVenti"
         },
         {
             "name": "자몽허니블랙티",
             "price": 3500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "TheVenti"
         },
         {
             "name": "트리플민트",
             "price": 2500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "TheVenti"
         },
         {
             "name": "허니레몬티",
             "price": 3500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "TheVenti"
         },
         {
             "name": "군고구마라떼",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "TheVenti"
         },
         {
             "name": "로얄밀크티",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "TheVenti"
         },
         {
             "name": "리치캐모마일",
             "price": 2500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "TheVenti"
         },
         {
             "name": "말차라떼",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "TheVenti"
         },
         {
             "name": "멜팅초코",
             "price": 3900,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "TheVenti"
         },
         {
             "name": "미숫가루라떼",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "TheVenti"
         },
         {
             "name": "애플히비스커스",
             "price": 2500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "TheVenti"
         },
         {
             "name": "자몽허니블랙티",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "TheVenti"
         },
         {
             "name": "트리플민트",
             "price": 2500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "TheVenti"
         },
         {
             "name": "허니레몬티",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "TheVenti"
         },
         {
             "name": "믹스커피",
             "price": 2500,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "TheVenti"
         },
         {
             "name": "바닐라딥라떼",
             "price": 3500,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "TheVenti"
         },
         {
             "name": "아메리카노",
             "price": 1800,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "TheVenti"
         },
         {
             "name": "연유라떼",
             "price": 3500,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "TheVenti"
         },
         {
             "name": "오트카페라떼",
             "price": 3800,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "TheVenti"
         },
         {
             "name": "카페라떼",
             "price": 3000,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "TheVenti"
         },
         {
             "name": "카페모카",
             "price": 3500,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "TheVenti"
         },
         {
             "name": "캬라멜마끼아또",
             "price": 3500,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "TheVenti"
         },
         {
             "name": "코코넛라떼",
             "price": 3500,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "TheVenti"
         },
         {
             "name": "헤이즐넛딥라떼",
             "price": 3500,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "TheVenti"
         },
         {
             "name": "코코넛라떼",
             "price": 3500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "TheVenti"
         },
         {
             "name": "믹스커피",
             "price": 2500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "TheVenti"
         },
         {
             "name": "바닐라딥라떼",
             "price": 3500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "TheVenti"
         },
         {
             "name": "아메리카노",
             "price": 1500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "TheVenti"
         },
         {
             "name": "연유라떼",
             "price": 3500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "TheVenti"
         },
         {
             "name": "오트카페라떼",
             "price": 3800,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "TheVenti"
         },
         {
             "name": "카페라떼",
             "price": 3000,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "TheVenti"
         },
         {
             "name": "카페모카",
             "price": 3500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "TheVenti"
         },
         {
             "name": "캬라멜마끼아또",
             "price": 3500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "TheVenti"
         },
         {
             "name": "플레인크로플",
             "price": 3000,
             "category": "Dessert",
-            "option": null,
             "brand": "TheVenti"
         },
         {
             "name": "고메소금빵",
             "price": 3000,
             "category": "Dessert",
-            "option": null,
             "brand": "TheVenti"
         },
         {
             "name": "달콤촉촉고구마빵",
             "price": 3500,
             "category": "Dessert",
-            "option": null,
             "brand": "TheVenti"
         },
         {
             "name": "마카다미아크루키",
             "price": 4200,
             "category": "Dessert",
-            "option": null,
             "brand": "TheVenti"
         },
         {
             "name": "스윗크룽지",
             "price": 1500,
             "category": "Dessert",
-            "option": null,
             "brand": "TheVenti"
         },
         {
             "name": "우유크림카스테라",
             "price": 4300,
             "category": "Dessert",
-            "option": null,
             "brand": "TheVenti"
         },
         {
             "name": "우유크림커피번",
             "price": 4000,
             "category": "Dessert",
-            "option": null,
             "brand": "TheVenti"
         },
         {
             "name": "크랜베리초코칩쿠키",
             "price": 3000,
             "category": "Dessert",
-            "option": null,
             "brand": "TheVenti"
         },
         {
             "name": "페페로니포카치아",
             "price": 4800,
             "category": "Dessert",
-            "option": null,
             "brand": "TheVenti"
         },
         {
             "name": "포슬쫀득감자빵",
             "price": 3500,
             "category": "Dessert",
-            "option": null,
             "brand": "TheVenti"
         },
         {
             "name": "버터버터마늘크로크무슈",
             "price": 3900,
             "category": "Dessert",
-            "option": null,
             "brand": "Mega"
         },
         {
             "name": "초코무스케이크",
             "price": 3500,
             "category": "Dessert",
-            "option": null,
             "brand": "Mega"
         },
         {
             "name": "초코스모어쿠키",
             "price": 2900,
             "category": "Dessert",
-            "option": null,
             "brand": "Mega"
         },
         {
             "name": "초콜릿칩쿠키",
             "price": 1800,
             "category": "Dessert",
-            "option": null,
             "brand": "Mega"
         },
         {
             "name": "치즈케이크",
             "price": 3500,
             "category": "Dessert",
-            "option": null,
             "brand": "Mega"
         },
         {
             "name": "치즈품은감자빵",
             "price": 3900,
             "category": "Dessert",
-            "option": null,
             "brand": "Mega"
         },
         {
             "name": "티라미수케이크",
             "price": 3500,
             "category": "Dessert",
-            "option": null,
             "brand": "Mega"
         },
         {
             "name": "핫치킨&딥치즈치아바타",
             "price": 4400,
             "category": "Dessert",
-            "option": null,
             "brand": "Mega"
         },
         {
             "name": "햄앤치즈샌드위치",
             "price": 2000,
             "category": "Dessert",
-            "option": null,
             "brand": "Mega"
         },
         {
             "name": "허니브레드",
             "price": 4500,
             "category": "Dessert",
-            "option": null,
             "brand": "Mega"
         },
         {
             "name": "청포도에이드",
             "price": 3500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Mega"
         },
         {
             "name": "곡물라떼",
             "price": 3300,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Mega"
         },
         {
             "name": "딸기라떼",
             "price": 3700,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Mega"
         },
         {
             "name": "라임모히또",
             "price": 3800,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Mega"
         },
         {
             "name": "레드오렌지자몽주스",
             "price": 4000,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Mega"
         },
         {
             "name": "레몬에이드",
             "price": 3500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Mega"
         },
         {
             "name": "로얄밀크티라떼",
             "price": 3700,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Mega"
         },
         {
             "name": "복숭아아이스티",
             "price": 3000,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Mega"
         },
         {
             "name": "블루레몬에이드",
             "price": 3500,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Mega"
         },
         {
             "name": "왕메가초코",
             "price": 4400,
-            "category": "Beverage",
-            "option": "ICE",
+            "category": "BeverageICE",
             "brand": "Mega"
         },
         {
             "name": "허니자몽블랙티",
             "price": 3700,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Mega"
         },
         {
             "name": "고구마라떼",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Mega"
         },
         {
             "name": "녹차",
             "price": 2500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Mega"
         },
         {
             "name": "녹차라떼",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Mega"
         },
         {
             "name": "로얄밀크티라떼",
             "price": 3700,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Mega"
         },
         {
             "name": "얼그레이",
             "price": 2500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Mega"
         },
         {
             "name": "유자차",
             "price": 3300,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Mega"
         },
         {
             "name": "캐모바일",
             "price": 2500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Mega"
         },
         {
             "name": "페퍼민트",
             "price": 2500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Mega"
         },
         {
             "name": "핫초코",
             "price": 3500,
-            "category": "Beverage",
-            "option": "HOT",
+            "category": "BeverageHOT",
             "brand": "Mega"
         },
         {
             "name": "헤이즐넛아메리카노",
             "price": 2700,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Mega"
         },
         {
             "name": "꿀아메리카노",
             "price": 2700,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Mega"
         },
         {
             "name": "바닐라라떼",
             "price": 3400,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Mega"
         },
         {
             "name": "아메리카노",
             "price": 2000,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Mega"
         },
         {
             "name": "카라멜마끼야또",
             "price": 3700,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Mega"
         },
         {
             "name": "콜드브루라떼",
             "price": 4000,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Mega"
         },
         {
             "name": "큐브라떼",
             "price": 4200,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Mega"
         },
         {
             "name": "피넛츠카페라떼",
             "price": 3900,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Mega"
         },
         {
             "name": "할메가미숫커피",
             "price": 2900,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Mega"
         },
         {
             "name": "헛개리카노",
             "price": 2400,
-            "category": "Coffee",
-            "option": "ICE",
+            "category": "CoffeeICE",
             "brand": "Mega"
         },
         {
             "name": "헤이즐넛라떼",
             "price": 3400,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Mega"
         },
         {
             "name": "꿀아메리카노",
             "price": 2700,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Mega"
         },
         {
             "name": "바닐라라떼",
             "price": 3400,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Mega"
         },
         {
             "name": "아메리카노",
             "price": 1500,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Mega"
         },
         {
             "name": "카라멜마끼아또",
             "price": 3700,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Mega"
         },
         {
             "name": "카페모카",
             "price": 3900,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Mega"
         },
         {
             "name": "티라미수라떼",
             "price": 3900,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Mega"
         },
         {
             "name": "피넛츠카페라떼",
             "price": 3900,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Mega"
         },
         {
             "name": "헛개리카노",
             "price": 2400,
-            "category": "Coffee",
-            "option": "HOT",
+            "category": "CoffeeHOT",
             "brand": "Mega"
         }
         

--- a/KioskApp/KioskApp/Beverages.json
+++ b/KioskApp/KioskApp/Beverages.json
@@ -1,881 +1,910 @@
-{
-    "beverage": [
-        {
-            "name": "사라다빵",
-            "price": 3000,
-            "category": "Dessert",
-            "brand": "Paik"
-        },
-        {
-            "name": "소세지빵",
-            "price": 3500,
-            "category": "Dessert",
-            "brand": "Paik"
-        },
-        {
-            "name": "소프트아이스크림",
-            "price": 2000,
-            "category": "Dessert",
-            "brand": "Paik"
-        },
-        {
-            "name": "쫀득감자빵",
-            "price": 2800,
-            "category": "Dessert",
-            "brand": "Paik"
-        },
-        {
-            "name": "쫀득고구마빵",
-            "price": 2800,
-            "category": "Dessert",
-            "brand": "Paik"
-        },
-        {
-            "name": "크리미단팥빵",
-            "price": 2000,
-            "category": "Dessert",
-            "brand": "Paik"
-        },
-        {
-            "name": "크리미슈",
-            "price": 2000,
-            "category": "Dessert",
-            "brand": "Paik"
-        },
-        {
-            "name": "햄치즈샌드위치",
-            "price": 3300,
-            "category": "Dessert",
-            "brand": "Paik"
-        },
-        {
-            "name": "고메버터소금빵",
-            "price": 2500,
-            "category": "Dessert",
-            "brand": "Paik"
-        },
-        {
-            "name": "딸기라떼",
-            "price": 3800,
-            "category": "BeverageICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "미숫가루",
-            "price": 2700,
-            "category": "BeverageICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "뱅쇼",
-            "price": 3800,
-            "category": "BeverageICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "아망추(아이스티+망고추가)",
-            "price": 3800,
-            "category": "BeverageICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "초코라떼",
-            "price": 3500,
-            "category": "BeverageICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "원조빽스치노(SOFT)",
-            "price": 3800,
-            "category": "BeverageICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "청포도에이드",
-            "price": 4000,
-            "category": "BeverageICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "쿠키크런치빽스치노(BASIC)",
-            "price": 3800,
-            "category": "BeverageICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "퐁당치노(바닐라)",
-            "price": 3800,
-            "category": "BeverageICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "플레인요거트스무디",
-            "price": 3500,
-            "category": "BeverageICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "황금캐모마일티",
-            "price": 2500,
-            "category": "BeverageHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "토피넛라떼",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "자몽티",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "유자티",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "쌍화차",
-            "price": 3000,
-            "category": "BeverageHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "뱅쇼",
-            "price": 3800,
-            "category": "BeverageHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "바나나라떼",
-            "price": 4000,
-            "category": "BeverageHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "민트초코라떼",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "레몬티",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "깔라만시티",
-            "price": 3000,
-            "category": "BeverageHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "달달연유라떼",
-            "price": 3700,
-            "category": "CoffeeICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "더블에스프레소",
-            "price": 1500,
-            "category": "CoffeeICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "바나나카페라떼",
-            "price": 4000,
-            "category": "CoffeeICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "바닐라라떼",
-            "price": 3700,
-            "category": "CoffeeICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "빽s라떼",
-            "price": 3000,
-            "category": "CoffeeICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "앗메리카노",
-            "price": 2000,
-            "category": "CoffeeICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "원조커피",
-            "price": 2500,
-            "category": "CoffeeICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "카라멜마키아또",
-            "price": 3500,
-            "category": "CoffeeICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "카페모카",
-            "price": 3500,
-            "category": "CoffeeICE",
-            "brand": "Paik"
-        },
-        {
-            "name": "바닐라라떼",
-            "price": 3700,
-            "category": "CoffeeHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "블랙펄카페라떼",
-            "price": 4500,
-            "category": "CoffeeHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "빽s라떼",
-            "price": 3000,
-            "category": "CoffeeHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "아샷추(달콤아이스티+샷추가)",
-            "price": 3000,
-            "category": "CoffeeHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "아이스크림바닐라라떼",
-            "price": 4400,
-            "category": "CoffeeHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "아이스크림카페라떼",
-            "price": 3700,
-            "category": "CoffeeHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "앗메리카노",
-            "price": 1500,
-            "category": "CoffeeHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "원조커피",
-            "price": 2500,
-            "category": "CoffeeHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "카라멜마키아또",
-            "price": 3500,
-            "category": "CoffeeHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "카페모카",
-            "price": 3500,
-            "category": "CoffeeHOT",
-            "brand": "Paik"
-        },
-        {
-            "name": "군고구마라떼",
-            "price": 3500,
-            "category": "BeverageICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "로얄밀크티",
-            "price": 3500,
-            "category": "BeverageICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "리치캐모마일",
-            "price": 2500,
-            "category": "BeverageICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "말차라떼",
-            "price": 3500,
-            "category": "BeverageICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "멜팅초코",
-            "price": 3900,
-            "category": "BeverageICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "미숫가루라떼",
-            "price": 3500,
-            "category": "BeverageICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "애플히비스커스",
-            "price": 2500,
-            "category": "BeverageICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "자몽허니블랙티",
-            "price": 3500,
-            "category": "BeverageICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "트리플민트",
-            "price": 2500,
-            "category": "BeverageICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "허니레몬티",
-            "price": 3500,
-            "category": "BeverageICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "군고구마라떼",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "로얄밀크티",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "리치캐모마일",
-            "price": 2500,
-            "category": "BeverageHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "말차라떼",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "멜팅초코",
-            "price": 3900,
-            "category": "BeverageHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "미숫가루라떼",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "애플히비스커스",
-            "price": 2500,
-            "category": "BeverageHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "자몽허니블랙티",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "트리플민트",
-            "price": 2500,
-            "category": "BeverageHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "허니레몬티",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "믹스커피",
-            "price": 2500,
-            "category": "CoffeeICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "바닐라딥라떼",
-            "price": 3500,
-            "category": "CoffeeICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "아메리카노",
-            "price": 1800,
-            "category": "CoffeeICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "연유라떼",
-            "price": 3500,
-            "category": "CoffeeICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "오트카페라떼",
-            "price": 3800,
-            "category": "CoffeeICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "카페라떼",
-            "price": 3000,
-            "category": "CoffeeICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "카페모카",
-            "price": 3500,
-            "category": "CoffeeICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "캬라멜마끼아또",
-            "price": 3500,
-            "category": "CoffeeICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "코코넛라떼",
-            "price": 3500,
-            "category": "CoffeeICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "헤이즐넛딥라떼",
-            "price": 3500,
-            "category": "CoffeeICE",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "코코넛라떼",
-            "price": 3500,
-            "category": "CoffeeHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "믹스커피",
-            "price": 2500,
-            "category": "CoffeeHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "바닐라딥라떼",
-            "price": 3500,
-            "category": "CoffeeHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "아메리카노",
-            "price": 1500,
-            "category": "CoffeeHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "연유라떼",
-            "price": 3500,
-            "category": "CoffeeHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "오트카페라떼",
-            "price": 3800,
-            "category": "CoffeeHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "카페라떼",
-            "price": 3000,
-            "category": "CoffeeHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "카페모카",
-            "price": 3500,
-            "category": "CoffeeHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "캬라멜마끼아또",
-            "price": 3500,
-            "category": "CoffeeHOT",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "플레인크로플",
-            "price": 3000,
-            "category": "Dessert",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "고메소금빵",
-            "price": 3000,
-            "category": "Dessert",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "달콤촉촉고구마빵",
-            "price": 3500,
-            "category": "Dessert",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "마카다미아크루키",
-            "price": 4200,
-            "category": "Dessert",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "스윗크룽지",
-            "price": 1500,
-            "category": "Dessert",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "우유크림카스테라",
-            "price": 4300,
-            "category": "Dessert",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "우유크림커피번",
-            "price": 4000,
-            "category": "Dessert",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "크랜베리초코칩쿠키",
-            "price": 3000,
-            "category": "Dessert",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "페페로니포카치아",
-            "price": 4800,
-            "category": "Dessert",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "포슬쫀득감자빵",
-            "price": 3500,
-            "category": "Dessert",
-            "brand": "TheVenti"
-        },
-        {
-            "name": "버터버터마늘크로크무슈",
-            "price": 3900,
-            "category": "Dessert",
-            "brand": "Mega"
-        },
-        {
-            "name": "초코무스케이크",
-            "price": 3500,
-            "category": "Dessert",
-            "brand": "Mega"
-        },
-        {
-            "name": "초코스모어쿠키",
-            "price": 2900,
-            "category": "Dessert",
-            "brand": "Mega"
-        },
-        {
-            "name": "초콜릿칩쿠키",
-            "price": 1800,
-            "category": "Dessert",
-            "brand": "Mega"
-        },
-        {
-            "name": "치즈케이크",
-            "price": 3500,
-            "category": "Dessert",
-            "brand": "Mega"
-        },
-        {
-            "name": "치즈품은감자빵",
-            "price": 3900,
-            "category": "Dessert",
-            "brand": "Mega"
-        },
-        {
-            "name": "티라미수케이크",
-            "price": 3500,
-            "category": "Dessert",
-            "brand": "Mega"
-        },
-        {
-            "name": "핫치킨&딥치즈치아바타",
-            "price": 4400,
-            "category": "Dessert",
-            "brand": "Mega"
-        },
-        {
-            "name": "햄앤치즈샌드위치",
-            "price": 2000,
-            "category": "Dessert",
-            "brand": "Mega"
-        },
-        {
-            "name": "허니브레드",
-            "price": 4500,
-            "category": "Dessert",
-            "brand": "Mega"
-        },
-        {
-            "name": "청포도에이드",
-            "price": 3500,
-            "category": "BeverageICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "곡물라떼",
-            "price": 3300,
-            "category": "BeverageICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "딸기라떼",
-            "price": 3700,
-            "category": "BeverageICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "라임모히또",
-            "price": 3800,
-            "category": "BeverageICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "레드오렌지자몽주스",
-            "price": 4000,
-            "category": "BeverageICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "레몬에이드",
-            "price": 3500,
-            "category": "BeverageICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "로얄밀크티라떼",
-            "price": 3700,
-            "category": "BeverageICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "복숭아아이스티",
-            "price": 3000,
-            "category": "BeverageICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "블루레몬에이드",
-            "price": 3500,
-            "category": "BeverageICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "왕메가초코",
-            "price": 4400,
-            "category": "BeverageICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "허니자몽블랙티",
-            "price": 3700,
-            "category": "BeverageHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "고구마라떼",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "녹차",
-            "price": 2500,
-            "category": "BeverageHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "녹차라떼",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "로얄밀크티라떼",
-            "price": 3700,
-            "category": "BeverageHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "얼그레이",
-            "price": 2500,
-            "category": "BeverageHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "유자차",
-            "price": 3300,
-            "category": "BeverageHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "캐모바일",
-            "price": 2500,
-            "category": "BeverageHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "페퍼민트",
-            "price": 2500,
-            "category": "BeverageHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "핫초코",
-            "price": 3500,
-            "category": "BeverageHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "헤이즐넛아메리카노",
-            "price": 2700,
-            "category": "CoffeeICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "꿀아메리카노",
-            "price": 2700,
-            "category": "CoffeeICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "바닐라라떼",
-            "price": 3400,
-            "category": "CoffeeICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "아메리카노",
-            "price": 2000,
-            "category": "CoffeeICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "카라멜마끼야또",
-            "price": 3700,
-            "category": "CoffeeICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "콜드브루라떼",
-            "price": 4000,
-            "category": "CoffeeICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "큐브라떼",
-            "price": 4200,
-            "category": "CoffeeICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "피넛츠카페라떼",
-            "price": 3900,
-            "category": "CoffeeICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "할메가미숫커피",
-            "price": 2900,
-            "category": "CoffeeICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "헛개리카노",
-            "price": 2400,
-            "category": "CoffeeICE",
-            "brand": "Mega"
-        },
-        {
-            "name": "헤이즐넛라떼",
-            "price": 3400,
-            "category": "CoffeeHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "꿀아메리카노",
-            "price": 2700,
-            "category": "CoffeeHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "바닐라라떼",
-            "price": 3400,
-            "category": "CoffeeHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "아메리카노",
-            "price": 1500,
-            "category": "CoffeeHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "카라멜마끼아또",
-            "price": 3700,
-            "category": "CoffeeHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "카페모카",
-            "price": 3900,
-            "category": "CoffeeHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "티라미수라떼",
-            "price": 3900,
-            "category": "CoffeeHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "피넛츠카페라떼",
-            "price": 3900,
-            "category": "CoffeeHOT",
-            "brand": "Mega"
-        },
-        {
-            "name": "헛개리카노",
-            "price": 2400,
-            "category": "CoffeeHOT",
-            "brand": "Mega"
-        }
-        
-    ]
-}
+[
+    {
+        "name": "사라다빵",
+        "price": 3000,
+        "category": "Dessert",
+        "brand": "Paik",
+        "recommended": true
+    },
+    {
+        "name": "소세지빵",
+        "price": 3500,
+        "category": "Dessert",
+        "brand": "Paik",
+        "recommended": true
+    },
+    {
+        "name": "소프트아이스크림",
+        "price": 2000,
+        "category": "Dessert",
+        "brand": "Paik"
+    },
+    {
+        "name": "쫀득감자빵",
+        "price": 2800,
+        "category": "Dessert",
+        "brand": "Paik"
+    },
+    {
+        "name": "쫀득고구마빵",
+        "price": 2800,
+        "category": "Dessert",
+        "brand": "Paik"
+    },
+    {
+        "name": "크리미단팥빵",
+        "price": 2000,
+        "category": "Dessert",
+        "brand": "Paik"
+    },
+    {
+        "name": "크리미슈",
+        "price": 2000,
+        "category": "Dessert",
+        "brand": "Paik"
+    },
+    {
+        "name": "햄치즈샌드위치",
+        "price": 3300,
+        "category": "Dessert",
+        "brand": "Paik",
+        "recommended": true
+    },
+    {
+        "name": "고메버터소금빵",
+        "price": 2500,
+        "category": "Dessert",
+        "brand": "Paik"
+    },
+    {
+        "name": "딸기라떼",
+        "price": 3800,
+        "category": "BeverageICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "미숫가루",
+        "price": 2700,
+        "category": "BeverageICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "뱅쇼",
+        "price": 3800,
+        "category": "BeverageICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "아망추(아이스티+망고추가)",
+        "price": 3800,
+        "category": "BeverageICE",
+        "brand": "Paik",
+        "recommended": true
+    },
+    {
+        "name": "초코라떼",
+        "price": 3500,
+        "category": "BeverageICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "원조빽스치노(SOFT)",
+        "price": 3800,
+        "category": "BeverageICE",
+        "brand": "Paik",
+        "recommended": true
+    },
+    {
+        "name": "청포도에이드",
+        "price": 4000,
+        "category": "BeverageICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "쿠키크런치빽스치노(BASIC)",
+        "price": 3800,
+        "category": "BeverageICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "퐁당치노(바닐라)",
+        "price": 3800,
+        "category": "BeverageICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "플레인요거트스무디",
+        "price": 3500,
+        "category": "BeverageICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "황금캐모마일티",
+        "price": 2500,
+        "category": "BeverageHOT",
+        "brand": "Paik",
+        "recommended": true
+    },
+    {
+        "name": "토피넛라떼",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "자몽티",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "유자티",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "Paik",
+        "recommended": true
+    },
+    {
+        "name": "쌍화차",
+        "price": 3000,
+        "category": "BeverageHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "뱅쇼",
+        "price": 3800,
+        "category": "BeverageHOT",
+        "brand": "Paik",
+        "recommended": true
+    },
+    {
+        "name": "바나나라떼",
+        "price": 4000,
+        "category": "BeverageHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "민트초코라떼",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "레몬티",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "Paik",
+        "recommended": true
+    },
+    {
+        "name": "깔라만시티",
+        "price": 3000,
+        "category": "BeverageHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "달달연유라떼",
+        "price": 3700,
+        "category": "CoffeeICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "더블에스프레소",
+        "price": 1500,
+        "category": "CoffeeICE",
+        "brand": "Paik",
+        "recommended": true
+    },
+    {
+        "name": "바나나카페라떼",
+        "price": 4000,
+        "category": "CoffeeICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "바닐라라떼",
+        "price": 3700,
+        "category": "CoffeeICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "빽s라떼",
+        "price": 3000,
+        "category": "CoffeeICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "앗메리카노",
+        "price": 2000,
+        "category": "CoffeeICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "원조커피",
+        "price": 2500,
+        "category": "CoffeeICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "카라멜마키아또",
+        "price": 3500,
+        "category": "CoffeeICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "카페모카",
+        "price": 3500,
+        "category": "CoffeeICE",
+        "brand": "Paik"
+    },
+    {
+        "name": "바닐라라떼",
+        "price": 3700,
+        "category": "CoffeeHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "블랙펄카페라떼",
+        "price": 4500,
+        "category": "CoffeeHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "빽s라떼",
+        "price": 3000,
+        "category": "CoffeeHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "아샷추(달콤아이스티+샷추가)",
+        "price": 3000,
+        "category": "CoffeeHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "아이스크림바닐라라떼",
+        "price": 4400,
+        "category": "CoffeeHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "아이스크림카페라떼",
+        "price": 3700,
+        "category": "CoffeeHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "앗메리카노",
+        "price": 1500,
+        "category": "CoffeeHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "원조커피",
+        "price": 2500,
+        "category": "CoffeeHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "카라멜마키아또",
+        "price": 3500,
+        "category": "CoffeeHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "카페모카",
+        "price": 3500,
+        "category": "CoffeeHOT",
+        "brand": "Paik"
+    },
+    {
+        "name": "군고구마라떼",
+        "price": 3500,
+        "category": "BeverageICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "로얄밀크티",
+        "price": 3500,
+        "category": "BeverageICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "리치캐모마일",
+        "price": 2500,
+        "category": "BeverageICE",
+        "brand": "TheVenti",
+        "recommended": true
+    },
+    {
+        "name": "말차라떼",
+        "price": 3500,
+        "category": "BeverageICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "멜팅초코",
+        "price": 3900,
+        "category": "BeverageICE",
+        "brand": "TheVenti",
+        "recommended": true
+    },
+    {
+        "name": "미숫가루라떼",
+        "price": 3500,
+        "category": "BeverageICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "애플히비스커스",
+        "price": 2500,
+        "category": "BeverageICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "자몽허니블랙티",
+        "price": 3500,
+        "category": "BeverageICE",
+        "brand": "TheVenti",
+        "recommended": true
+    },
+    {
+        "name": "트리플민트",
+        "price": 2500,
+        "category": "BeverageICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "허니레몬티",
+        "price": 3500,
+        "category": "BeverageICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "군고구마라떼",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "로얄밀크티",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "리치캐모마일",
+        "price": 2500,
+        "category": "BeverageHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "말차라떼",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "멜팅초코",
+        "price": 3900,
+        "category": "BeverageHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "미숫가루라떼",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "애플히비스커스",
+        "price": 2500,
+        "category": "BeverageHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "자몽허니블랙티",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "트리플민트",
+        "price": 2500,
+        "category": "BeverageHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "허니레몬티",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "믹스커피",
+        "price": 2500,
+        "category": "CoffeeICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "바닐라딥라떼",
+        "price": 3500,
+        "category": "CoffeeICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "아메리카노",
+        "price": 1800,
+        "category": "CoffeeICE",
+        "brand": "TheVenti",
+        "recommended": true
+    },
+    {
+        "name": "연유라떼",
+        "price": 3500,
+        "category": "CoffeeICE",
+        "brand": "TheVenti",
+        "recommended": true
+    },
+    {
+        "name": "오트카페라떼",
+        "price": 3800,
+        "category": "CoffeeICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "카페라떼",
+        "price": 3000,
+        "category": "CoffeeICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "카페모카",
+        "price": 3500,
+        "category": "CoffeeICE",
+        "brand": "TheVenti",
+        "recommended": true
+    },
+    {
+        "name": "캬라멜마끼아또",
+        "price": 3500,
+        "category": "CoffeeICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "코코넛라떼",
+        "price": 3500,
+        "category": "CoffeeICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "헤이즐넛딥라떼",
+        "price": 3500,
+        "category": "CoffeeICE",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "코코넛라떼",
+        "price": 3500,
+        "category": "CoffeeHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "믹스커피",
+        "price": 2500,
+        "category": "CoffeeHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "바닐라딥라떼",
+        "price": 3500,
+        "category": "CoffeeHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "아메리카노",
+        "price": 1500,
+        "category": "CoffeeHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "연유라떼",
+        "price": 3500,
+        "category": "CoffeeHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "오트카페라떼",
+        "price": 3800,
+        "category": "CoffeeHOT",
+        "brand": "TheVenti",
+        "recommended": true
+    },
+    {
+        "name": "카페라떼",
+        "price": 3000,
+        "category": "CoffeeHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "카페모카",
+        "price": 3500,
+        "category": "CoffeeHOT",
+        "brand": "TheVenti",
+        "recommended": true
+    },
+    {
+        "name": "캬라멜마끼아또",
+        "price": 3500,
+        "category": "CoffeeHOT",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "플레인크로플",
+        "price": 3000,
+        "category": "Dessert",
+        "brand": "TheVenti",
+        "recommended": true
+    },
+    {
+        "name": "고메소금빵",
+        "price": 3000,
+        "category": "Dessert",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "달콤촉촉고구마빵",
+        "price": 3500,
+        "category": "Dessert",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "마카다미아크루키",
+        "price": 4200,
+        "category": "Dessert",
+        "brand": "TheVenti",
+        "recommended": true
+    },
+    {
+        "name": "스윗크룽지",
+        "price": 1500,
+        "category": "Dessert",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "우유크림카스테라",
+        "price": 4300,
+        "category": "Dessert",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "우유크림커피번",
+        "price": 4000,
+        "category": "Dessert",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "크랜베리초코칩쿠키",
+        "price": 3000,
+        "category": "Dessert",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "페페로니포카치아",
+        "price": 4800,
+        "category": "Dessert",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "포슬쫀득감자빵",
+        "price": 3500,
+        "category": "Dessert",
+        "brand": "TheVenti"
+    },
+    {
+        "name": "버터버터마늘크로크무슈",
+        "price": 3900,
+        "category": "Dessert",
+        "brand": "Mega"
+    },
+    {
+        "name": "초코무스케이크",
+        "price": 3500,
+        "category": "Dessert",
+        "brand": "Mega"
+    },
+    {
+        "name": "초코스모어쿠키",
+        "price": 2900,
+        "category": "Dessert",
+        "brand": "Mega"
+    },
+    {
+        "name": "초콜릿칩쿠키",
+        "price": 1800,
+        "category": "Dessert",
+        "brand": "Mega"
+    },
+    {
+        "name": "치즈케이크",
+        "price": 3500,
+        "category": "Dessert",
+        "brand": "Mega"
+    },
+    {
+        "name": "치즈품은감자빵",
+        "price": 3900,
+        "category": "Dessert",
+        "brand": "Mega"
+    },
+    {
+        "name": "티라미수케이크",
+        "price": 3500,
+        "category": "Dessert",
+        "brand": "Mega",
+        "recommended": true
+    },
+    {
+        "name": "핫치킨&딥치즈치아바타",
+        "price": 4400,
+        "category": "Dessert",
+        "brand": "Mega",
+        "recommended": true
+    },
+    {
+        "name": "햄앤치즈샌드위치",
+        "price": 2000,
+        "category": "Dessert",
+        "brand": "Mega"
+    },
+    {
+        "name": "허니브레드",
+        "price": 4500,
+        "category": "Dessert",
+        "brand": "Mega",
+        "recommended": true
+    },
+    {
+        "name": "청포도에이드",
+        "price": 3500,
+        "category": "BeverageICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "곡물라떼",
+        "price": 3300,
+        "category": "BeverageICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "딸기라떼",
+        "price": 3700,
+        "category": "BeverageICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "라임모히또",
+        "price": 3800,
+        "category": "BeverageICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "레드오렌지자몽주스",
+        "price": 4000,
+        "category": "BeverageICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "레몬에이드",
+        "price": 3500,
+        "category": "BeverageICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "로얄밀크티라떼",
+        "price": 3700,
+        "category": "BeverageICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "복숭아아이스티",
+        "price": 3000,
+        "category": "BeverageICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "블루레몬에이드",
+        "price": 3500,
+        "category": "BeverageICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "왕메가초코",
+        "price": 4400,
+        "category": "BeverageICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "허니자몽블랙티",
+        "price": 3700,
+        "category": "BeverageHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "고구마라떼",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "녹차",
+        "price": 2500,
+        "category": "BeverageHOT",
+        "brand": "Mega",
+        "recommended": true
+    },
+    {
+        "name": "녹차라떼",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "로얄밀크티라떼",
+        "price": 3700,
+        "category": "BeverageHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "얼그레이",
+        "price": 2500,
+        "category": "BeverageHOT",
+        "brand": "Mega",
+        "recommended": true
+    },
+    {
+        "name": "유자차",
+        "price": 3300,
+        "category": "BeverageHOT",
+        "brand": "Mega",
+        "recommended": true
+    },
+    {
+        "name": "캐모바일",
+        "price": 2500,
+        "category": "BeverageHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "페퍼민트",
+        "price": 2500,
+        "category": "BeverageHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "핫초코",
+        "price": 3500,
+        "category": "BeverageHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "헤이즐넛아메리카노",
+        "price": 2700,
+        "category": "CoffeeICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "꿀아메리카노",
+        "price": 2700,
+        "category": "CoffeeICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "바닐라라떼",
+        "price": 3400,
+        "category": "CoffeeICE",
+        "brand": "Mega",
+        "recommended": true
+    },
+    {
+        "name": "아메리카노",
+        "price": 2000,
+        "category": "CoffeeICE",
+        "brand": "Mega",
+        "recommended": true
+    },
+    {
+        "name": "카라멜마끼야또",
+        "price": 3700,
+        "category": "CoffeeICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "콜드브루라떼",
+        "price": 4000,
+        "category": "CoffeeICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "큐브라떼",
+        "price": 4200,
+        "category": "CoffeeICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "피넛츠카페라떼",
+        "price": 3900,
+        "category": "CoffeeICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "할메가미숫커피",
+        "price": 2900,
+        "category": "CoffeeICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "헛개리카노",
+        "price": 2400,
+        "category": "CoffeeICE",
+        "brand": "Mega"
+    },
+    {
+        "name": "헤이즐넛라떼",
+        "price": 3400,
+        "category": "CoffeeHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "꿀아메리카노",
+        "price": 2700,
+        "category": "CoffeeHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "바닐라라떼",
+        "price": 3400,
+        "category": "CoffeeHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "아메리카노",
+        "price": 1500,
+        "category": "CoffeeHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "카라멜마끼아또",
+        "price": 3700,
+        "category": "CoffeeHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "카페모카",
+        "price": 3900,
+        "category": "CoffeeHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "티라미수라떼",
+        "price": 3900,
+        "category": "CoffeeHOT",
+        "brand": "Mega",
+        "recommended": true
+    },
+    {
+        "name": "피넛츠카페라떼",
+        "price": 3900,
+        "category": "CoffeeHOT",
+        "brand": "Mega"
+    },
+    {
+        "name": "헛개리카노",
+        "price": 2400,
+        "category": "CoffeeHOT",
+        "brand": "Mega",
+        "recommended": true
+    }
+    
+]
+ 

--- a/KioskApp/KioskApp/Beverages.json
+++ b/KioskApp/KioskApp/Beverages.json
@@ -138,7 +138,7 @@
         "brand": "Paik"
     },
     {
-        "name": "유자티",
+        "name": "유자차",
         "price": 3500,
         "category": "BeverageHOT",
         "brand": "Paik",
@@ -185,116 +185,116 @@
     {
         "name": "달달연유라떼",
         "price": 3700,
-        "category": "CoffeeICE",
+        "category": "CoffeeHOT",
         "brand": "Paik"
     },
     {
         "name": "더블에스프레소",
         "price": 1500,
-        "category": "CoffeeICE",
+        "category": "CoffeeHOT",
         "brand": "Paik",
         "recommended": true
     },
     {
         "name": "바나나카페라떼",
         "price": 4000,
-        "category": "CoffeeICE",
+        "category": "CoffeeHOT",
         "brand": "Paik"
     },
     {
         "name": "바닐라라떼",
         "price": 3700,
-        "category": "CoffeeICE",
+        "category": "CoffeeHOT",
         "brand": "Paik"
     },
     {
         "name": "빽s라떼",
         "price": 3000,
-        "category": "CoffeeICE",
+        "category": "CoffeeHOT",
         "brand": "Paik"
     },
     {
         "name": "앗메리카노",
         "price": 2000,
-        "category": "CoffeeICE",
+        "category": "CoffeeHOT",
         "brand": "Paik"
     },
     {
         "name": "원조커피",
         "price": 2500,
-        "category": "CoffeeICE",
+        "category": "CoffeeHOT",
         "brand": "Paik"
     },
     {
         "name": "카라멜마키아또",
         "price": 3500,
-        "category": "CoffeeICE",
+        "category": "CoffeeHOT",
         "brand": "Paik"
     },
     {
         "name": "카페모카",
         "price": 3500,
-        "category": "CoffeeICE",
+        "category": "CoffeeHOT",
         "brand": "Paik"
     },
     {
         "name": "바닐라라떼",
         "price": 3700,
-        "category": "CoffeeHOT",
+        "category": "CoffeeICE",
         "brand": "Paik"
     },
     {
         "name": "블랙펄카페라떼",
         "price": 4500,
-        "category": "CoffeeHOT",
+        "category": "CoffeeICE",
         "brand": "Paik"
     },
     {
         "name": "빽s라떼",
         "price": 3000,
-        "category": "CoffeeHOT",
+        "category": "CoffeeICE",
         "brand": "Paik"
     },
     {
         "name": "아샷추(달콤아이스티+샷추가)",
         "price": 3000,
-        "category": "CoffeeHOT",
+        "category": "CoffeeICE",
         "brand": "Paik"
     },
     {
         "name": "아이스크림바닐라라떼",
         "price": 4400,
-        "category": "CoffeeHOT",
+        "category": "CoffeeICE",
         "brand": "Paik"
     },
     {
         "name": "아이스크림카페라떼",
         "price": 3700,
-        "category": "CoffeeHOT",
+        "category": "CoffeeICE",
         "brand": "Paik"
     },
     {
         "name": "앗메리카노",
         "price": 1500,
-        "category": "CoffeeHOT",
+        "category": "CoffeeICE",
         "brand": "Paik"
     },
     {
         "name": "원조커피",
         "price": 2500,
-        "category": "CoffeeHOT",
+        "category": "CoffeeICE",
         "brand": "Paik"
     },
     {
         "name": "카라멜마키아또",
         "price": 3500,
-        "category": "CoffeeHOT",
+        "category": "CoffeeICE",
         "brand": "Paik"
     },
     {
         "name": "카페모카",
         "price": 3500,
-        "category": "CoffeeHOT",
+        "category": "CoffeeICE",
         "brand": "Paik"
     },
     {
@@ -608,7 +608,7 @@
         "brand": "Mega"
     },
     {
-        "name": "초코무스케이크",
+        "name": "초코무스케익",
         "price": 3500,
         "category": "Dessert",
         "brand": "Mega"
@@ -626,7 +626,7 @@
         "brand": "Mega"
     },
     {
-        "name": "치즈케이크",
+        "name": "치즈케익",
         "price": 3500,
         "category": "Dessert",
         "brand": "Mega"
@@ -638,7 +638,7 @@
         "brand": "Mega"
     },
     {
-        "name": "티라미수케이크",
+        "name": "티라미수케익",
         "price": 3500,
         "category": "Dessert",
         "brand": "Mega",

--- a/KioskApp/KioskApp/Cache/ImageCacheManager.swift
+++ b/KioskApp/KioskApp/Cache/ImageCacheManager.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+class ImageCacheManager {
+    
+    static let shared = ImageCacheManager()
+    
+    private init() {}
+    
+    private var cache = NSCache<NSString, UIImage>()
+    
+    func image(from urlPath: String) async throws -> UIImage? {
+        let urlNSString = NSString(string: urlPath)
+        if let image = cache.object(forKey: urlNSString) {
+            return image
+        }
+        guard let url = URL(string: urlPath) else {
+            throw(NetworkError.invalidURL)
+        }
+        
+        let session = URLSession(configuration: .ephemeral)
+        let response = try await session.data(from: url)
+        
+        guard let httpResponse = response.1 as? HTTPURLResponse else {
+            throw(NetworkError.transportError)
+        }
+        guard (200..<300).contains(httpResponse.statusCode) else {
+            throw(NetworkError.serverError(code: httpResponse.statusCode))
+        }
+        guard let image = UIImage(data: response.0) else {
+            throw(NetworkError.decodingError)
+        }
+        
+        cache.setObject(image, forKey: urlNSString)
+        return image
+    }
+    
+}

--- a/KioskApp/KioskApp/DataService.swift
+++ b/KioskApp/KioskApp/DataService.swift
@@ -6,7 +6,7 @@ enum DataError: Error {
 }
 
 class DataService {
-    func fetchData(completion: @escaping (Result< Product, Error>) -> Void) {
+    func fetchData(completion: @escaping (Result< [Beverage], Error>) -> Void) {
         guard let path = Bundle.main.path(forResource: "Beverages", ofType: "json") else {
             completion(.failure(DataError.fileNotFound))
             return
@@ -14,7 +14,7 @@ class DataService {
         
         do {
             let data = try Data(contentsOf: URL(fileURLWithPath: path))
-            let response = try JSONDecoder().decode(Product.self, from: data)
+            let response = try JSONDecoder().decode([Beverage].self, from: data)
             completion(.success(response))
         } catch {
             print("JSON 파싱 에러 : \(error)")

--- a/KioskApp/KioskApp/Model/Model.swift
+++ b/KioskApp/KioskApp/Model/Model.swift
@@ -16,55 +16,14 @@ enum Brand: String, Decodable {
     case mega = "Mega"
 }
 
-/// 모든 브랜드의 커피 배열을 담은 구조체
-struct Product: Decodable {
-    let beverage: [Beverage]
-    
-    var baiksProduct: [Beverage] {
-        return beverage.filter {
-            $0.brand == .paik
-        }
-    }
-    
-    var theVentiProduct: [Beverage] {
-        return beverage.filter {
-            $0.brand == .theVenti
-        }
-    }
-    var megaProduct: [Beverage] {
-        return beverage.filter {
-            $0.brand == .mega
-        }
-    }
-    
-    func fetchData(brand: Brand,
-                   category: Category,
-                   option: Option? = nil) -> [Beverage] {
-        return beverage.filter {
-            $0.category == category &&
-            $0.brand == brand &&
-            $0.option == option
-        }
-    }
-    
-    func fecthRecommendedData(brand: Brand,
-                              category: Category,
-                              option: Option? = nil) -> [Beverage] {
-        return self.fetchData(brand: brand, category: category, option: option).filter{ $0.recommended == true }
-    }
-}
-
 /// 제품 하나의 세부정보 리스트
 struct Beverage: Decodable, Hashable {
     let name: String
     let price: Int
     let category: Category
-    let option: Option?
     let brand: Brand
     var recommended: Bool?
-    var imageName: String {
-        return "\(category.rawValue)" + "\(option == nil ? "-" : "\(option?.rawValue)-")" + "\(name)" + "-\(brand.rawValue)"
-    }
+    var imageName: String?
 }
 
 
@@ -93,9 +52,11 @@ struct OrderItem {
 struct NetworkResponse: Decodable {
     let name: String
     let downloadURL: String?
+    let path: String?
     
     enum CodingKeys: String, CodingKey {
         case name
         case downloadURL = "download_url"
+        case path
     }
 }

--- a/KioskApp/KioskApp/Model/Model.swift
+++ b/KioskApp/KioskApp/Model/Model.swift
@@ -2,8 +2,10 @@ import Foundation
 
 /// 카테고리 (Coffee, Beverage, Desert)
 enum Category: String, Decodable {
-    case coffee = "Coffee"
-    case beverage = "Beverage"
+    case coffeeHot = "CoffeeHOT"
+    case coffeeIce = "CoffeeICE"
+    case beverageHot = "BeverageHOT"
+    case beverageIce = "BeverageICE"
     case dessert = "Dessert"
 }
 
@@ -12,12 +14,6 @@ enum Brand: String, Decodable {
     case paik = "Paik"
     case theVenti = "TheVenti"
     case mega = "Mega"
-}
-
-/// 커피와 음료의 옵션, 디저트는 none  (HOT, ICE, none)
-enum Option: String, Decodable{
-    case hot = "HOT"
-    case ice = "ICE"
 }
 
 /// 모든 브랜드의 커피 배열을 담은 구조체
@@ -59,7 +55,7 @@ struct Product: Decodable {
 }
 
 /// 제품 하나의 세부정보 리스트
-struct Beverage: Decodable {
+struct Beverage: Decodable, Hashable {
     let name: String
     let price: Int
     let category: Category
@@ -67,7 +63,7 @@ struct Beverage: Decodable {
     let brand: Brand
     var recommended: Bool?
     var imageName: String {
-        return "\(category.rawValue)" + "\(option == nil ? "-" : "\(option?.rawValue!)-")" + "\(name)" + "-\(brand.rawValue)"
+        return "\(category.rawValue)" + "\(option == nil ? "-" : "\(option?.rawValue)-")" + "\(name)" + "-\(brand.rawValue)"
     }
 }
 

--- a/KioskApp/KioskApp/Network/DataProvider.swift
+++ b/KioskApp/KioskApp/Network/DataProvider.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+final class DataProvider {
+    
+    private let networkManager: NetworkManager
+    private let dataService: DataService
+    
+    init(networkManager: NetworkManager = .init(), dataService: DataService = .init()) {
+        self.networkManager = networkManager
+        self.dataService = dataService
+    }
+    
+//     Beverage.json으로 부터 데이터 불러오기
+    private func configureBeverage() -> [Beverage] {
+        let dataService = DataService()
+        var items: [Beverage] = []
+        dataService.fetchData { result in
+            switch result {
+            case .success(let success):
+                items = success
+            case .failure(let failure):
+                print(failure)
+            }
+        }
+        return items
+    }
+    
+//     Git KioskStorage의 이미지파일들 모두 불러오기 (병렬 처리)
+    private func configureNetworkResponse() async throws -> [NetworkResponse] {
+        var responses: [NetworkResponse] = []
+        try await withThrowingTaskGroup(of: [NetworkResponse].self) {[weak self] group in
+            guard let self else { return }
+            for i in 0..<NetworkSequence.array.count {
+                let brand = NetworkSequence.array[i].brand
+                let category = NetworkSequence.array[i].category
+                group.addTask {
+                    return try await self.networkManager.fetchData(for: [NetworkResponse].self,
+                                                                   brand: brand,
+                                                                   category: category)
+                }
+            }
+            for try await response in group {
+                responses += response
+            }
+        }
+        return responses
+    }
+    
+//     불러온 이미지 캐시에 저장
+    private func configureCache(response: [NetworkResponse]) async throws {
+        try await withThrowingTaskGroup(of: (Void).self) {[weak self] group in
+            guard let self else { return }
+            for i in 0..<response.count {
+                group.addTask {
+                    return try await ImageCacheManager.shared.image(from: response[i].downloadURL ?? "")
+                }
+            }
+            for try await _ in group { }
+        }
+    }
+    
+//     Beverage의 ImageName에 이미지 URL 할당
+    private func assignImageURL(from response: [NetworkResponse], to beverages: inout [Beverage]) {
+        for i in 0..<response.count {
+            let arr = response[i].name.split(separator: ".")
+            let name = arr.first ?? ""
+            
+            
+            guard let path = response[i].path?.split(separator: "/") else { continue }
+            let brand = String(path[0])
+            let category = String(path[1])
+            
+            for j in 0..<beverages.count {
+                if beverages[j].name == name &&
+                    beverages[j].brand.rawValue == brand &&
+                    beverages[j].category.rawValue == category {
+                    beverages[j].imageName = response[i].downloadURL
+                }
+            }
+        }
+    }
+    
+//    데이터 준비 프로세스
+//    1. Beverage.json 데이터 파싱
+//    2. Git Repo의 이미지 불러오기
+//    3. 불러온 이미지 캐시 저장
+//    4. Beverage의 ImageName에 이미지 URL 저장
+//    탈출 클로저로 준비된 데이터를 전달
+    func process(completion: @escaping ([Beverage]) -> Void) {
+        Task {
+            var beverages = configureBeverage()
+            let response = try await configureNetworkResponse()
+            try await configureCache(response: response)
+            assignImageURL(from: response, to: &beverages)
+            completion(beverages)
+        }
+    }
+}

--- a/KioskApp/KioskApp/Network/NetworkManager.swift
+++ b/KioskApp/KioskApp/Network/NetworkManager.swift
@@ -15,9 +15,8 @@ final class NetworkManager {
     
     func fetchData<T: Decodable>(for type: T.Type ,
                                  brand: Brand? = nil,
-                                 category: Category? = nil,
-                                 option: Option? = nil) async throws -> T {
-        let urlComponents = urlComponenetHandler.fetchURLComponents(brand: brand, category: category, option: option)
+                                 category: Category? = nil) async throws -> T {
+        let urlComponents = urlComponenetHandler.fetchURLComponents(brand: brand, category: category)
         
         guard let url = urlComponents.url else {
             throw(NetworkError.invalidURL)

--- a/KioskApp/KioskApp/Network/NetworkManager.swift
+++ b/KioskApp/KioskApp/Network/NetworkManager.swift
@@ -6,6 +6,42 @@ enum NetworkError: Error {
     case missingData
     case invalidURL
     case transportError
+    
+    var customLocalizedDescription: String {
+        switch self {
+        case .decodingError:
+            return "Decoding Error"
+        case .serverError(code: let code):
+            return "Server Error (\(code))"
+        case .missingData:
+            return "Missing Data"
+        case .invalidURL:
+            return "Invalid URL"
+        case .transportError:
+            return "Transport Error"
+        }
+    }
+}
+
+enum NetworkSequence {
+    static let array: [(brand: Brand, category: Category)] =
+    [
+        (.paik, .dessert),
+        (.paik, .coffeeHot),
+        (.paik, .coffeeIce),
+        (.paik, .beverageHot),
+        (.paik, .beverageIce),
+        (.theVenti, .dessert),
+        (.theVenti, .coffeeHot),
+        (.theVenti, .coffeeIce),
+        (.theVenti, .beverageHot),
+        (.theVenti, .beverageIce),
+        (.mega, .dessert),
+        (.mega, .coffeeHot),
+        (.mega, .coffeeIce),
+        (.mega, .beverageHot),
+        (.mega, .beverageIce),
+    ]
 }
 
 final class NetworkManager {

--- a/KioskApp/KioskApp/Network/URLComponentsHandler.swift
+++ b/KioskApp/KioskApp/Network/URLComponentsHandler.swift
@@ -2,8 +2,7 @@ import Foundation
 
 final class URLComponentHandler {
     func fetchURLComponents(brand: Brand? = nil,
-                            category: Category? = nil,
-                            option: Option? = nil) -> URLComponents {
+                            category: Category? = nil) -> URLComponents {
         var components = URLComponents()
         components.scheme = "https"
         components.host = "api.github.com"
@@ -19,9 +18,8 @@ final class URLComponentHandler {
             return components
         }
         
-        let categoryOption = category + "\(option?.rawValue ?? "")"
         paths.append(brand)
-        paths.append(categoryOption)
+        paths.append(category)
         
         components.path = "/" + "\(paths.joined(separator: "/"))"
         return components


### PR DESCRIPTION
📌 관련 이슈
Closed: #20 

📌 변경 사항 및 이유
- 앱 시작시 데이터 준비 프로세스 구현 ( Beverage.json 데이터 디코딩 -> Git Repo의 이미지 불러오기 -> 이미지 캐시 저장 -> [Beverage]의 ImageName에 이미지 URL 저장)
- 이미지를 모두 불러오는데 순차실행하면 대략 3초~5초 소요 -> UX면에서 좋지 않음 -> 이를 병렬처리로 구현

📌 PR Point
- DataProvider: 데이터 준비 프로세스 객체
- Beverage.json 파일 수정
- Beverage 모델 수정 (option 제거하고 category에 통합)
- Product 모델 삭제
- ImageCacheManager: 이미지 캐시 저장 , 싱글톤

📌 참고 사항 (To-Do)
- 이미지 준비 과정에서 로딩창 띄워서 사용자로부터 데이터 준비중임을 알림이 필요
- DataProvider에서 데이터 준비를 어느 타이밍에 해야할지 고려 (LauchScreen 실행타임에 할지, VC의 viewdidload에 할지)