### PR TITLE
Feat/#22

### DIFF
--- a/KioskApp/KioskApp/CoffeeBrandButtonView.swift
+++ b/KioskApp/KioskApp/CoffeeBrandButtonView.swift
@@ -70,7 +70,7 @@ class CoffeeBrandButtonView: UIView {
     private func coffeeBrandMenu() {
         let coffeeBrandItems = [
             UIAction(title: "메가커피", handler: { _ in self.coffeeBrandChanged(brandName: "Mega")}),
-            UIAction(title: "빽다방", handler: { _ in self.coffeeBrandChanged(brandName: "paik")}),
+            UIAction(title: "빽다방", handler: { _ in self.coffeeBrandChanged(brandName: "Paik")}),
             UIAction(title: "더벤티", handler: { _ in self.coffeeBrandChanged(brandName: "TheVenti")})
         ]
         

--- a/KioskApp/KioskApp/OderList/OrderItemCell.swift
+++ b/KioskApp/KioskApp/OderList/OrderItemCell.swift
@@ -16,6 +16,11 @@ protocol OrderItemCellDelegate: AnyObject {
 }
 
 class OrderItemCell: UITableViewCell {
+    
+    private(set) var orderItem: OrderItem?
+    
+    weak var delegate: OrderItemCellDelegate?
+    
     // MARK: - UI Components
     // 뷰에 들어갈 컴포넌트들을 정의하는 공간
     /// 셀 전체를 감싸는 수평 스택 뷰입니다.
@@ -42,7 +47,6 @@ class OrderItemCell: UITableViewCell {
     private let removeButton = UIButton(type: .system)
     
     /// 셀에서 발생하는 액션을 전달할 델리게이트입니다.
-    weak var delegate: OrderItemCellDelegate?
     
     // MARK: - Initializers
     // init(frame:) 또는 required init?(coder:) 구현
@@ -189,6 +193,7 @@ class OrderItemCell: UITableViewCell {
     // MARK: - Public Methods
     /// 주문 항목(OrderItem)을 받아 UI 요소에 값을 설정합니다.
     func configure(with order: OrderItem) {
+        self.orderItem = order
         titleLabel.text = "(\(order.brand)) \(order.name)"
         quantityLabel.text = "\(order.count)"
         priceLabel.text = "\(order.price * order.count)원"

--- a/KioskApp/KioskApp/OderList/OrderListView.swift
+++ b/KioskApp/KioskApp/OderList/OrderListView.swift
@@ -7,9 +7,21 @@
 import UIKit
 import SnapKit
 
+protocol OrderListViewDataSource: AnyObject {
+    var orderList: [OrderItem] { get }
+}
+
+protocol OrderListViewDelegate: AnyObject {
+    func orderListViewCancelButtonDidTap()
+    func orderListViewOrderButtonDidTap()
+}
+
 /// 장바구니 화면을 구성하는 메인 뷰입니다.
 /// 타이틀, 주문 리스트, 총 가격, 주문/취소 버튼 등으로 구성되어 있습니다.
 class OrderListView: UIView {
+    
+    weak var dataSource: OrderListViewDataSource?
+    weak var delegate: OrderListViewDelegate?
     
     // MARK: - UI Components
 
@@ -39,6 +51,7 @@ class OrderListView: UIView {
     /// 코드로 뷰를 초기화할 때 호출됩니다.
     override init(frame: CGRect) {
         super.init(frame: frame)
+//        orderListTableView.tableView.dataSource = self
 //        orderListTableView.delegate = self
         setupSubViews()
         setupLayout()
@@ -128,7 +141,7 @@ class OrderListView: UIView {
         addSubview(buttonStackView)
         
         // 버튼 액션 설정
-//        cancelButton.addTarget(self, action: #selector(didTapCancel), for: .touchUpInside)
+        cancelButton.addTarget(self, action: #selector(didTapCancel), for: .touchUpInside)
     }
 
     
@@ -136,10 +149,9 @@ class OrderListView: UIView {
     
     /// "주문취소" 버튼을 눌렀을 때 실행됩니다.
     /// OrderListManager의 리스트를 초기화하고 UI를 갱신합니다.
-//    @objc private func didTapCancel() {
-//        OrderListManager.shared.reset()   // 모든 항목 제거
-//        reloadTable()                     // 테이블 및 총 가격 갱신
-//    }
+    @objc private func didTapCancel() {
+        delegate?.orderListViewCancelButtonDidTap()
+    }
 
     
     // MARK: - Public Methods
@@ -147,20 +159,20 @@ class OrderListView: UIView {
     /// 테이블을 다시 그리며, 내부 높이도 계산하여 업데이트합니다.
     func reloadTable() {
         orderListTableView.reloadData()
-        
         DispatchQueue.main.async {
             self.orderListTableView.layoutIfNeeded()
             let height = self.orderListTableView.intrinsicContentHeight()
             self.orderListTableViewHeightConstraint?.update(offset: max(140, height))
-//            self.updateTotalPrice()
+            self.updateTotalPrice()
         }
     }
 //
 //    / 현재 장바구니의 총 가격을 계산해 텍스트로 표시합니다.
-//    func updateTotalPrice() {
-//        let total = OrderListManager.shared.totalPrice()
-//        totalPriceLabel.text = "총 가격: \(total)원"
-//    }
+    func updateTotalPrice() {
+        let total = dataSource?.orderList.reduce(0) { $0 + $1.price * $1.count }
+        print(total)
+        totalPriceLabel.text = "총 가격: \(total)원"
+    }
 //
 //    /// OrderListTableView 내부에서 수량이 변경되었을 때 호출되는 델리게이트 메서드입니다.
 //    func orderListTableViewDidUpdate() {

--- a/KioskApp/KioskApp/ProductCell.swift
+++ b/KioskApp/KioskApp/ProductCell.swift
@@ -70,7 +70,7 @@ class ProductCell: UICollectionViewCell {
     // 셀 외곽에 그림자 효과
     private func applyShadow() {
         self.layer.shadowColor = UIColor.black.cgColor // 그림자 색상
-        self.layer.shadowOpacity = 0.1                 // 그림자 투명도 (연하게)
+        self.layer.shadowOpacity = 0.12                 // 그림자 투명도 (연하게)
         self.layer.shadowRadius = 10                   // 그림자 퍼짐 정도
         self.layer.shadowOffset = CGSize(width: 0, height: 6) // 아래 방향으로 그림자
     }

--- a/KioskApp/KioskApp/ProductGridView.swift
+++ b/KioskApp/KioskApp/ProductGridView.swift
@@ -8,10 +8,16 @@
 import UIKit
 import SnapKit
 
+protocol productGridViewDelegate: AnyObject {
+    func collectionViewCellDidTap(item: Beverage)
+}
+
 class ProductGridView: UIView {
     
+    weak var delegate: productGridViewDelegate?
+    
     // 상품 목록을 표시할 컬렉션 뷰
-    private(set) lazy var collectionView: UICollectionView = {
+    private lazy var collectionView: UICollectionView = {
         let collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.collectionViewLayout())
         collectionView.alwaysBounceVertical = false // 수직 바운스 비활성화
         collectionView.backgroundColor = .clear
@@ -40,6 +46,7 @@ class ProductGridView: UIView {
         super.init(frame: .zero)
         setupUI()
         configureCollectionView()
+        collectionView.delegate = self
     }
     
     required init?(coder: NSCoder) {
@@ -155,5 +162,12 @@ class ProductGridView: UIView {
         if items.count > 0 {
             collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .left, animated: false)
         }
+    }
+}
+
+extension ProductGridView: UICollectionViewDelegate {
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let item = datasource.itemIdentifier(for: indexPath) else { return }
+        delegate?.collectionViewCellDidTap(item: item)
     }
 }

--- a/KioskApp/KioskApp/ProductGridView.swift
+++ b/KioskApp/KioskApp/ProductGridView.swift
@@ -150,5 +150,9 @@ class ProductGridView: UIView {
     func configure(items: [Beverage]) {
         configureSnapshot(items: items)
         configurePageControl(count: items.count)
+        
+        if items.count > 0 {
+            collectionView.scrollToItem(at: IndexPath(item: 0, section: 0), at: .left, animated: false)
+        }
     }
 }

--- a/KioskApp/KioskApp/ProductGridView.swift
+++ b/KioskApp/KioskApp/ProductGridView.swift
@@ -24,6 +24,7 @@ class ProductGridView: UIView {
         let pageControl = UIPageControl()
         pageControl.currentPageIndicatorTintColor = .black // 현재 페이지 색상
         pageControl.pageIndicatorTintColor = .systemGray    // 나머지 점 색상
+        pageControl.isUserInteractionEnabled = false
         return pageControl
     }()
     

--- a/KioskApp/KioskApp/ViewController.swift
+++ b/KioskApp/KioskApp/ViewController.swift
@@ -21,7 +21,7 @@ class ViewController: UIViewController {
         setupUI()
         setupDelegate()
         bindViewModel()
-        viewModel.fetchTestModel()
+        viewModel.fetchProducts()
     }
     
     private func setupAddSubView() {
@@ -98,7 +98,7 @@ class ViewController: UIViewController {
     }
     
     private func coffeeBrandImageChange(brand: Brand) {
-        let imageName = "\(viewModel.selectedBrand.rawValue)" + "Logo"
+        let imageName = "\(brand.rawValue)" + "Logo"
         coffeeBrandButtonView.coffeeBrandImageChange(imageName: imageName)
     }
     

--- a/KioskApp/KioskApp/ViewController.swift
+++ b/KioskApp/KioskApp/ViewController.swift
@@ -74,7 +74,7 @@ class ViewController: UIViewController {
     private func setupDelegate() {
         coffeeBrandButtonView.delegate = self
         coffeeCategoryView.delegate = self
-        productGirdView.collectionView.delegate = self
+        productGirdView.delegate = self
         orderListView.orderListTableView.tableView.dataSource = self
     }
     
@@ -94,6 +94,10 @@ class ViewController: UIViewController {
         
         viewModel.categoryChanged = { [weak self] in
             self?.configureUI()
+        }
+        
+        viewModel.orderProductsChanged = { [weak self] in
+            self?.orderListView.reloadTable()
         }
     }
     
@@ -141,11 +145,9 @@ extension ViewController: CoffeeCategoryCollectionViewDelegate {
     }
 }
 
-extension ViewController: UICollectionViewDelegate {
-    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
-        guard let item = productGirdView.datasource.itemIdentifier(for: indexPath) else { return }
+extension ViewController: productGridViewDelegate {
+    func collectionViewCellDidTap(item: Beverage) {
         viewModel.addOrder(item)
-        orderListView.reloadTable()
     }
 }
 

--- a/KioskApp/KioskApp/ViewController.swift
+++ b/KioskApp/KioskApp/ViewController.swift
@@ -19,7 +19,7 @@ class ViewController: UIViewController {
         self.view.backgroundColor = #colorLiteral(red: 0.9490196078, green: 0.8235294118, blue: 0.2, alpha: 1)
         setupAddSubView()
         setupUI()
-        setupDelegate()
+        configureSubViews()
         bindViewModel()
         viewModel.fetchProducts()
     }
@@ -71,10 +71,12 @@ class ViewController: UIViewController {
         }
     }
     
-    private func setupDelegate() {
+    private func configureSubViews() {
         coffeeBrandButtonView.delegate = self
         coffeeCategoryView.delegate = self
         productGirdView.delegate = self
+        orderListView.dataSource = self
+        orderListView.delegate = self
         orderListView.orderListTableView.tableView.dataSource = self
     }
     
@@ -151,14 +153,45 @@ extension ViewController: productGridViewDelegate {
     }
 }
 
+extension ViewController: OrderListViewDataSource, OrderListViewDelegate {
+    var orderList: [OrderItem] {
+        viewModel.orderList
+    }
+    
+    func orderListViewCancelButtonDidTap() {
+        viewModel.orderCacelAll()
+    }
+    
+    func orderListViewOrderButtonDidTap() {
+        print("dfasfs")
+    }
+}
+
 extension ViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        viewModel.orderList.count
+        return viewModel.orderList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "OrderItemCell", for: indexPath) as! OrderItemCell
         cell.configure(with: viewModel.orderList[indexPath.row])
+        cell.delegate = self
         return cell
+    }
+}
+
+extension ViewController: OrderItemCellDelegate {
+    func orderItemCellDidTapIncrement(_ cell: OrderItemCell) {
+        guard let orderItem = cell.orderItem else { return }
+        viewModel.orderCountIncreament(orderItem)
+    }
+    
+    func orderItemCellDidTapDecrement(_ cell: OrderItemCell) {
+        guard let orderItem = cell.orderItem else { return }
+        viewModel.orderCountDecreament(orderItem)
+    }
+    
+    func orderItemCellDidTapRemove(_ cell: OrderItemCell) {
+        print(1)
     }
 }

--- a/KioskApp/KioskApp/ViewModel/OrderViewModel.swift
+++ b/KioskApp/KioskApp/ViewModel/OrderViewModel.swift
@@ -47,14 +47,14 @@ final class OrderViewModel {
     /// 현재 주문한 상품 리스트
     private(set) var orderList: [OrderItem] = [] {
         didSet {
-            orderProductsChanged?(orderList)
+            orderProductsChanged?()
         }
     }
     
     // MARK: - 클로저
     
     /// 주문 목록이 변경될 때 호출되는 클로저
-    var orderProductsChanged: (([OrderItem]) -> Void)?
+    var orderProductsChanged: (() -> Void)?
     
     /// 카테고리가 변경될 때 호출되는 클로저
     var categoryChanged: (() -> Void)?
@@ -104,22 +104,28 @@ final class OrderViewModel {
     /// 주문 항목의 수량을 1 증가시킵니다.
     ///
     /// - Parameter beverage: 수량을 증가시킬 음료
-    func orderCountIncreament(_ beverage: Beverage) {
+    func orderCountIncreament(_ beverage: OrderItem) {
         guard let index = orderList.firstIndex(where: { $0.name == beverage.name && $0.brand == beverage.brand }) else { return }
         orderList[index].increaseCount()
+        orderProductsChanged?()
     }
     
     /// 주문 항목의 수량을 1 감소시킵니다.
     /// 수량이 1일 경우 해당 항목을 삭제합니다.
     ///
     /// - Parameter beverage: 수량을 감소시킬 음료
-    func orderCountDecreament(_ beverage: Beverage) {
+    func orderCountDecreament(_ beverage: OrderItem) {
         guard let index = orderList.firstIndex(where: { $0.name == beverage.name && $0.brand == beverage.brand }) else { return }
         if orderList[index].count > 1 {
             orderList[index].decreaseCount()
         } else {
             orderList.remove(at: index)
         }
+        orderProductsChanged?()
+    }
+    
+    func orderCacelAll() {
+        orderList.removeAll()
     }
     
     // MARK: - 필터 변경

--- a/KioskApp/KioskApp/ViewModel/OrderViewModel.swift
+++ b/KioskApp/KioskApp/ViewModel/OrderViewModel.swift
@@ -23,13 +23,6 @@ final class OrderViewModel {
     
     // MARK: - 상태
     
-    /// 현재 선택된 카테고리 (기본값: .coffee)
-    private(set) var selectedCategory: Category = .coffee {
-        didSet {
-            categoryChanged?()
-        }
-    }
-    
     /// 현재 선택된 브랜드 (기본값: .mega)
     private(set) var selectedBrand: Brand = .mega {
         didSet {
@@ -37,10 +30,10 @@ final class OrderViewModel {
         }
     }
     
-    /// 현재 주문한 상품 리스트
-    private(set) var orderList: [OrderItem] = [] {
+    /// 현재 선택된 카테고리 (기본값: .coffee)
+    private(set) var selectedCategory: Category = .coffee {
         didSet {
-            orderProductsChanged?(orderList)
+            categoryChanged?()
         }
     }
     
@@ -48,6 +41,13 @@ final class OrderViewModel {
     private(set) var selectedOption: Option? = .ice {
         didSet {
             categoryChanged?()
+        }
+    }
+    
+    /// 현재 주문한 상품 리스트
+    private(set) var orderList: [OrderItem] = [] {
+        didSet {
+            orderProductsChanged?(orderList)
         }
     }
     
@@ -68,18 +68,20 @@ final class OrderViewModel {
     /// 선택된 조건에 따라 필터링된 상품 목록을 사용할 수 있게 됩니다.
     ///
     /// - Parameter completion: 로딩 결과를 알리는 완료 핸들러 (성공: `.success`, 실패: `.failure`)
-    func fetchProductData(completion: ((Result<Void, Error>) -> Void)? = nil) {
-        let service = DataService()
-        service.fetchData { [weak self] result in
+    
+    
+    func fetchProducts() {
+        DataService.fetchData { result in
             switch result {
             case .success(let product):
-                self?.product = product
-                completion?(.success(()))
+                self.product = product
+                self.categoryChanged?()
             case .failure(let error):
-                completion?(.failure(error))
+                print(error.localizedDescription)
             }
         }
     }
+    
     
     // MARK: - 주문 관리 메소드
     
@@ -136,7 +138,6 @@ final class OrderViewModel {
     /// 현재 선택된 브랜드를 변경합니다.
     /// - Parameter brand: 변경할 브랜드
     func changeBrand(_ brand: Brand) {
-        
         selectedBrand = brand
         selectedCategory = .coffee
         selectedOption = .hot


### PR DESCRIPTION
## 📌 관련 이슈
- Closed: #22 

## 📌 변경 사항 및 이유
- 브랜드 또는 카테고리 변경 시 상품 페이지를 첫 페이지로 리셋
- UIPageControl의 유저 액션 비활성화
- 장바구니 관련 로직 처리

## 📌 PR Point
- VC는 자신이 소유한 뷰에만 관심을 갖고,
  각 뷰 내부의 UI 컴포넌트는 해당 뷰 내에서만 관리하도록 책임을 분리하려고 했습니다.
- 현재 일부 컴포넌트만 분리 적용된 상태이며, 점진적으로 구조 개선을 진행할 예정입니다.

## 📌 참고 사항
- 향후 View → ViewController → ViewModel 간의 흐름을 더 명확히 정리할 계획입니다.